### PR TITLE
EW-574 exclude report of coverage from sonarcloud analysis

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,7 +10,7 @@ sonar.sources=.
 sonar.tests=.
 sonar.test.inclusions=**/*.spec.ts,**/*.integration-spec.ts
 sonar.test.exclusions=**/node_modules/**
-sonar.artifacts.exclusions=**/lcov-report/**
+sonar.exclusions=**/lcov-report/**
 
 # Location for the coverage report files
 sonar.javascript.lcov.reportPaths=artifacts/lcov.info

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,7 +9,8 @@ sonar.projectVersion=1.0
 sonar.sources=.
 sonar.tests=.
 sonar.test.inclusions=**/*.spec.ts,**/*.integration-spec.ts
-sonar.test.exclusions=**/node_modules/**, **/lcov-report/**
+sonar.test.exclusions=**/node_modules/**
+sonar.exclusions=**/lcov-report/**
 
 # Location for the coverage report files
 sonar.javascript.lcov.reportPaths=artifacts/lcov.info

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,7 +9,7 @@ sonar.projectVersion=1.0
 sonar.sources=.
 sonar.tests=.
 sonar.test.inclusions=**/*.spec.ts,**/*.integration-spec.ts
-sonar.test.exclusions=**/node_modules/**, **/lcov-report/**
+sonar.test.exclusions=**/node_modules/**
 
 # Location for the coverage report files
 sonar.javascript.lcov.reportPaths=artifacts/lcov.info

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,7 +9,7 @@ sonar.projectVersion=1.0
 sonar.sources=.
 sonar.tests=.
 sonar.test.inclusions=**/*.spec.ts,**/*.integration-spec.ts
-sonar.test.exclusions=**/node_modules/**
+sonar.test.exclusions=**/node_modules/**, **/lcov-report/**
 
 # Location for the coverage report files
 sonar.javascript.lcov.reportPaths=artifacts/lcov.info

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,7 +10,7 @@ sonar.sources=.
 sonar.tests=.
 sonar.test.inclusions=**/*.spec.ts,**/*.integration-spec.ts
 sonar.test.exclusions=**/node_modules/**
-sonar.exclusions=**/lcov-report/**
+sonar.artifacts.exclusions=**/lcov-report/**
 
 # Location for the coverage report files
 sonar.javascript.lcov.reportPaths=artifacts/lcov.info


### PR DESCRIPTION
# Description
This pull request fixes the bug of false positives on sonarcloud. Report of coverage will be excluded form the analysis of the code.

## Links to Tickets or other pull requests
Ticket: https://ticketsystem.dbildungscloud.de/browse/EW-574

## Changes
reduce the finding of false positives at the sonarcloud project of dbildungs-iam-server.

## Datasecurity

<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment

<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should includes following informations:
  - What is required for deployment?
  - Envirement variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts

<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Screenshots of UI changes

<!--
  only needed for visual changes

  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
